### PR TITLE
[Fix] dark 모드 초기 렌더링 시 테마 깜빡임 현상

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -5,13 +5,13 @@ function Footer() {
                 <div className="flex space-x-6 items-center">
                     <a
                         href="https://github.com/decollzoq"
-                        className="hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg p-2 transition-colors duration-500"
+                        className="hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg p-2"
                     >
                         GitHub{" "}
                     </a>
                     <a
                         href="https://velog.io/@decollzoq/posts"
-                        className="hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg p-2 transition-colors duration-500"
+                        className="hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg p-2"
                     >
                         Velog
                     </a>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -6,25 +6,25 @@ function Header() {
     const { isDark, toggle } = useDarkMode();
 
     return (
-        <header className="sticky top-0 bg-white dark:bg-gray-900 z-10 transition-colors duration-500">
+        <header className="sticky top-0 bg-white dark:bg-gray-900 z-10">
             <nav className="container max-w-4xl mx-auto px-6 py-3 flex justify-between">
                 <a href="/" className="flex items-center">
                     <h1 className="font-bold text-2xl">SEON</h1>
                 </a>
                 <div className="flex gap-6 place-items-center ">
-                    <div className="hover:text-primary transition-colors duration-500">
+                    <div className="hover:text-primary">
                         <a href="/" className="text-lg">
                             Home
                         </a>
                     </div>
                     <button
                         onClick={toggle}
-                        className="hover:bg-gray-100 dark:hover:bg-gray-800 p-2 rounded-xl w-10 h-10 transition-colors duration-500"
+                        className="hover:bg-gray-100 dark:hover:bg-gray-800 p-2 rounded-xl w-10 h-10 "
                     >
                         {isDark ? (
-                            <IoSunnyOutline className="mx-auto w-5 h-5 text-gray-50 transition-all duration-500" />
+                            <IoSunnyOutline className="mx-auto w-5 h-5 text-gray-50 " />
                         ) : (
-                            <FaRegMoon className="mx-auto transition-all duration-500" />
+                            <FaRegMoon className="mx-auto" />
                         )}
                     </button>
                 </div>

--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -5,7 +5,7 @@ function PostCard({ post }: { post: Post }) {
     return (
         <article
             key={post.id}
-            className="text-gray-900 hover:text-primary hover:-translate-y-2 transition-transform duration-500"
+            className="hover:text-primary hover:-translate-y-2 transition-transform duration-500"
         >
             <a href={`/posts/${post.id}`}>
                 <div className="container flex flex-col">
@@ -20,14 +20,15 @@ function PostCard({ post }: { post: Post }) {
                         </div>
                     </div>
                     <div className="mt-4">
-                        <h3 className="text-xl mb-3 font-bold dark:text-gray-50 transition-colors duration-500">
+                        <h3 className="text-xl mb-3 font-bold ">
                             {post.title}
                         </h3>
+
                         <div className="flex space-x-2 mb-2">
                             {post.tags.map((tag, tdx) => (
                                 <span
                                     key={tdx}
-                                    className="bg-gray-100 rounded-lg text-xs text-gray-600 dark:text-gray-50 dark:bg-gray-800 font-light px-2 py-1 transition-colors duration-500"
+                                    className="bg-gray-50 rounded-xl text-xs text-gray-500 dark:text-gray-400 dark:bg-gray-800 font-light px-2 py-1"
                                 >
                                     # {tag}
                                 </span>

--- a/client/src/components/PostHeader.tsx
+++ b/client/src/components/PostHeader.tsx
@@ -6,10 +6,10 @@ function PostHeader({ post }: Props) {
     return (
         <header className="flex flex-col items-start gap-4 mb-8">
             <div className="flex flex-row items-center gap-3">
-                <div className="text-sm bg-primary text-gray-50 rounded-3xl px-3 py-1 dark:bg-primary-dark transition-colors duration-500">
+                <div className="text-sm bg-primary text-gray-50 rounded-3xl px-3 py-1 dark:bg-primary-dark">
                     {post.category}
                 </div>
-                <div className="text-sm text-gray-600 dark:text-gray-400 transition-colors duration-500">
+                <div className="text-sm text-gray-600 dark:text-gray-400">
                     {post.date}
                 </div>
             </div>

--- a/client/src/components/PostNavigation.tsx
+++ b/client/src/components/PostNavigation.tsx
@@ -13,11 +13,11 @@ function PostNavigation({ prevPost, nextPost }: NavigationProps) {
                 {prevPost && (
                     <a
                         href={`/posts/${prevPost.id}`}
-                        className="p-4 flex space-x-4 items-center w-full text-gray-900 dark:text-gray-50 dark:hover:bg-gray-700 hover:bg-gray-50 rounded-lg transition-colors duration-500 hover:text-primary"
+                        className="p-4 flex space-x-4 items-center w-full text-gray-900 dark:text-gray-50 dark:hover:bg-gray-700 hover:bg-gray-50 rounded-lg hover:text-primary"
                     >
                         <IoIosArrowBack className="text-2xl" />
                         <div className="flex flex-col items-start gap-1 min-w-0">
-                            <div className="text-gray-500 dark:text-gray-300 transition-colors duration-500 text-sm">
+                            <div className="text-gray-500 dark:text-gray-300 text-sm">
                                 이전 글
                             </div>
                             <div className="w-full text-xl leading-10 text-start truncate ">
@@ -32,10 +32,10 @@ function PostNavigation({ prevPost, nextPost }: NavigationProps) {
                 {nextPost && (
                     <a
                         href={`/posts/${nextPost.id}`}
-                        className="p-4 flex space-x-4 items-center w-full justify-end text-gray-900 dark:text-gray-50 dark:hover:bg-gray-700 hover:bg-gray-50 rounded-lg transition-colors duration-500 hover:text-primary"
+                        className="p-4 flex space-x-4 items-center w-full justify-end text-gray-900 dark:text-gray-50 dark:hover:bg-gray-700 hover:bg-gray-50 rounded-lg hover:text-primary"
                     >
                         <div className="flex flex-col items-end gap-1 min-w-0">
-                            <h2 className="text-gray-500 dark:text-gray-300 transition-colors duration-500 text-sm">
+                            <h2 className="text-gray-500 dark:text-gray-300  text-sm">
                                 다음 글
                             </h2>
                             <p className="w-full text-xl leading-10 text-end truncate">

--- a/client/src/components/PostTagList.tsx
+++ b/client/src/components/PostTagList.tsx
@@ -3,11 +3,11 @@ interface TagListProps {
 }
 function PostTagList({ tags }: TagListProps) {
     return (
-        <div className="border-t-gray-200 dark:border-t-gray-600 pt-8 space-x-2 border-t-[1px] transition-colors duration-500">
+        <div className="border-t-gray-200 dark:border-t-gray-600 pt-8 space-x-2 border-t-[1px]">
             {tags.map((tag, tdx) => (
                 <span
                     key={tdx}
-                    className="bg-gray-50 rounded-2xl text-sm text-gray-400 dark:text-gray-300 dark:bg-gray-800 font-normal px-4 py-2 transition-colors duration-500"
+                    className="bg-gray-50 rounded-2xl text-sm text-gray-400 dark:text-gray-300 dark:bg-gray-800 font-normal px-4 py-2"
                 >
                     # {tag}
                 </span>

--- a/client/src/routes/pages/Home.tsx
+++ b/client/src/routes/pages/Home.tsx
@@ -80,11 +80,11 @@ function Home() {
                 <section className="my-12 flex space-x-3 items-center font-semibold max-w-4xl">
                     <button
                         onClick={() => setCategory("All")}
-                        className={`h-10 w-16 rounded-3xl transition-colors duration-500
+                        className={`h-10 w-16 rounded-3xl 
                         ${
                             category === "All"
-                                ? "bg-primary text-gray-50"
-                                : "bg-gray-100 text-gray-600 hover:bg-gray-150 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-300"
+                                ? "bg-primary text-gray-50 dark:bg-primary-dark"
+                                : "bg-gray-50 text-gray-600 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
                         }`}
                     >
                         All
@@ -94,11 +94,11 @@ function Home() {
                             <button
                                 key={idx}
                                 onClick={() => setCategory(c)}
-                                className={`h-10 w-16 rounded-3xl transition-colors duration-500
+                                className={`h-10 w-16 rounded-3xl
                         ${
                             category === c
-                                ? "bg-primary text-gray-50"
-                                : "bg-gray-100 text-gray-600 hover:bg-gray-150 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-300"
+                                ? "bg-primary text-gray-50 dark:bg-primary-dark"
+                                : "bg-gray-50 text-gray-600 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
                         }`}
                             >
                                 {c}
@@ -108,7 +108,7 @@ function Home() {
                 </section>
 
                 <section className="mb-16 max-w-4xl mx-auto">
-                    <div className="container grid grid-cols-1 sm:grid-cols-2 gap-12 items-center max-w-full ">
+                    <div className="container grid grid-cols-1 sm:grid-cols-2 gap-12 items-start max-w-full ">
                         {filteredPosts.map((p: Post) => (
                             <PostCard key={p.id} post={p} />
                         ))}

--- a/client/src/routes/pages/PostDetails.tsx
+++ b/client/src/routes/pages/PostDetails.tsx
@@ -32,8 +32,13 @@ function PostDetails() {
 
                 <PostTagList tags={post.tags} />
 
-                <footer className="mb-12 flex flex-col mt-12 text-gray-800 text-sm text-center font-normal dark:text-gray-300 border-t-gray-200 dark:border-t-gray-600 pt-8 space-y-4 border-t-[1px] transition-colors duration-500">
-                    <h1>{post.category} 카테고리의 다른 글</h1>
+                <footer className="mb-12 flex flex-col mt-12 text-gray-800 text-sm text-center font-normal dark:text-gray-300 border-t-gray-200 dark:border-t-gray-600 pt-8 space-y-4 border-t-[1px]">
+                    <h1>
+                        <span className="text-primary-dark">
+                            {post.category}{" "}
+                        </span>
+                        카테고리의 다른 글
+                    </h1>
                     <PostNavigation
                         prevPost={sameCategoryPosts[postIdx - 1]}
                         nextPost={sameCategoryPosts[postIdx + 1]}

--- a/client/src/style/global.css
+++ b/client/src/style/global.css
@@ -4,7 +4,7 @@
 
 @layer base {
     body {
-        @apply bg-white text-gray-900 transition-colors duration-500;
+        @apply bg-white text-gray-900;
     }
 
     .dark body {

--- a/client/src/style/global.d.ts
+++ b/client/src/style/global.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css" {
+    const content: { [className: string]: string };
+    export default content;
+}


### PR DESCRIPTION
### 관련 이슈 #9 

### PR 타입
버그 수정 

### 반영 브랜치 
`fix/darkmode` -> `develop`

### 작업 내용
- [x] 초기 렌더링 시 다크모드 테마 즉시 반영하도록 수정
- [x] 시스템 테마 변경 시 즉각적인 반응하도록 수정
- [x] 홈화면-포스트카드의 태그 스타일 수정
- [x] global.d.ts 파일을 추가하여 CSS 및 에센 모듈 선언을 지원

### 스크린샷
**개선 전**
<img width="3644" height="2172" alt="화면 기록 2026-04-16 오후 10 11 21" src="https://github.com/user-attachments/assets/320ffd4d-8c54-4fa3-bb95-b62bbb06b282" />

**개선 후**
<img width="3644" height="2172" alt="화면 기록 2026-04-16 오후 10 11 34" src="https://github.com/user-attachments/assets/32b183a7-19e1-4cfc-b248-b2fe96c18cb2" />
