### PR TITLE
[Refactor] Home 페이지 구조 개선 및 Context API 기반 상태 관리 도입

### DIFF
--- a/client/src/components/CategoryFilter.tsx
+++ b/client/src/components/CategoryFilter.tsx
@@ -1,0 +1,38 @@
+import { categoryList } from "../data/posts";
+import { useCategory } from "../contexts/providers/CategoryProvider";
+function CategoryFiler() {
+    const { category, setCategory } = useCategory();
+    return (
+        <section className="my-12 flex space-x-3 items-center font-semibold max-w-4xl">
+            <button
+                onClick={() => setCategory("All")}
+                className={`h-10 w-16 rounded-3xl 
+                        ${
+                            category === "All"
+                                ? "bg-primary text-gray-50 dark:bg-primary-dark"
+                                : "bg-gray-50 text-gray-600 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                        }`}
+            >
+                All
+            </button>
+            <div className="flex space-x-3">
+                {categoryList.map((c, idx) => (
+                    <button
+                        key={idx}
+                        onClick={() => setCategory(c)}
+                        className={`h-10 w-16 rounded-3xl
+                        ${
+                            category === c
+                                ? "bg-primary text-gray-50 dark:bg-primary-dark"
+                                : "bg-gray-50 text-gray-600 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                        }`}
+                    >
+                        {c}
+                    </button>
+                ))}
+            </div>
+        </section>
+    );
+}
+
+export default CategoryFiler;

--- a/client/src/components/FeaturedSlider.tsx
+++ b/client/src/components/FeaturedSlider.tsx
@@ -1,0 +1,69 @@
+import { IoIosArrowBack } from "react-icons/io";
+import { IoIosArrowForward } from "react-icons/io";
+import { Post } from "../types/post";
+import { useState } from "react";
+
+interface FeaturedSliderProps {
+    posts: Post[];
+}
+
+function FeaturedSlider({ posts }: FeaturedSliderProps) {
+    const [currentSlide, setCurrentSlide] = useState(0); // 현재 슬라이드 번호
+    let slidePost = posts[currentSlide]; // 현재 슬라이드 게시물
+    function nextCard() {
+        setCurrentSlide((prev) => (prev === posts.length - 1 ? 0 : prev + 1));
+    }
+    function prevCard() {
+        setCurrentSlide((prev) => (prev === 0 ? posts.length - 1 : prev + 1));
+    }
+    return (
+        <div className="container max-w-full relative aspect-[21/9] rounded-2xl overflow-hidden bg-gray-100 dark:bg-gray-500">
+            <a href={`/posts/${slidePost.id}`}>
+                <img
+                    src={slidePost.thumbnail}
+                    alt={slidePost.title}
+                    className="object-cover w-full h-full"
+                />
+                <div className="absolute text-gray-50 bottom-0 px-9 py-8 flex sm:flex-col gap-2 items-center sm:items-start">
+                    <h1 className="text-lg sm:text-2xl md:text-3xl font-bold text-gray-100">
+                        {slidePost.title}
+                    </h1>
+                    <p className="text-sm sm:text-base md:text-lg text-gray-200">
+                        {slidePost.date}
+                    </p>
+                </div>
+            </a>
+
+            {/* 슬라이더 컨트롤 */}
+            <div className="absolute top-1/2 left-4">
+                <button
+                    onClick={() => prevCard()}
+                    className="bg-gray-600/30 backdrop-blur-sm hover:bg-gray-600/60 rounded-full h-10 w-10 transition-colors"
+                >
+                    <IoIosArrowBack className="w-6 h-6 ml-[7px] text-gray-50" />
+                </button>
+            </div>
+            <div className="absolute top-1/2 right-4">
+                <button
+                    onClick={() => nextCard()}
+                    className="bg-gray-600/30  backdrop-blur-sm hover:bg-gray-600/60 rounded-full h-10 w-10 transition-colors"
+                >
+                    <IoIosArrowForward className="w-6 h-6 ml-[9px] text-gray-50" />
+                </button>
+            </div>
+
+            {/* 인디케이터 */}
+            <div className="absolute bottom-4 max-w-full container flex items-center justify-center space-x-2">
+                {posts.map((p, idx) => (
+                    <button
+                        key={idx}
+                        onClick={() => setCurrentSlide(idx)}
+                        className={`hover:cursor-default ${currentSlide === idx ? "bg-gray-50 w-8" : "bg-gray-400 w-2"} h-2 rounded-xl transition-all`}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export default FeaturedSlider;

--- a/client/src/components/PostGrid.tsx
+++ b/client/src/components/PostGrid.tsx
@@ -1,0 +1,18 @@
+import { Post } from "../types/post";
+import PostCard from "./PostCard";
+interface PostGridProps {
+    posts: Post[];
+}
+function PostGrid({ posts }: PostGridProps) {
+    return (
+        <section className="mb-16 max-w-4xl mx-auto">
+            <div className="container grid grid-cols-1 sm:grid-cols-2 gap-12 items-start max-w-full ">
+                {posts.map((p: Post) => (
+                    <PostCard key={p.id} post={p} />
+                ))}
+            </div>
+        </section>
+    );
+}
+
+export default PostGrid;

--- a/client/src/contexts/providers/CategoryProvider.tsx
+++ b/client/src/contexts/providers/CategoryProvider.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext, useState } from "react";
+
+interface CategroyState {
+    category: string;
+    setCategory: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const CategoryContext = createContext<CategroyState | null>(null);
+
+export function CategoryProvider({ children }: { children: React.ReactNode }) {
+    const [category, setCategory] = useState("All");
+    return (
+        <CategoryContext.Provider value={{ category, setCategory }}>
+            {children}
+        </CategoryContext.Provider>
+    );
+}
+
+export function useCategory() {
+    const context = useContext(CategoryContext);
+    if (!context) {
+        throw new Error("useCategory must be used within a CategroyProvider");
+    }
+    return context;
+}

--- a/client/src/routes/layouts/Default.tsx
+++ b/client/src/routes/layouts/Default.tsx
@@ -2,12 +2,15 @@ import { Outlet } from "react-router";
 import { ScrollRestoration } from "react-router";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
+import { CategoryProvider } from "../../contexts/providers/CategoryProvider";
 
 export default function DefaultLayout() {
     return (
         <>
             <Header />
-            <Outlet />
+            <CategoryProvider>
+                <Outlet />
+            </CategoryProvider>
             <ScrollRestoration />
             <Footer />
         </>

--- a/client/src/routes/pages/Home.tsx
+++ b/client/src/routes/pages/Home.tsx
@@ -1,119 +1,26 @@
-import { categoryList, MOCK_POSTS } from "../../data/posts";
-import { useState } from "react";
-import { Post } from "../../types/post";
-import { IoIosArrowBack } from "react-icons/io";
-import { IoIosArrowForward } from "react-icons/io";
-
-import PostCard from "../../components/PostCard";
+import { MOCK_POSTS } from "../../data/posts";
+import { useCategory } from "../../contexts/providers/CategoryProvider";
+import FeaturedSlider from "../../components/FeaturedSlider";
+import CategoryFiler from "../../components/CategoryFilter";
+import PostGrid from "../../components/PostGrid";
 
 function Home() {
-    const [category, setCategory] = useState("All");
+    const { category } = useCategory();
     const filteredPosts =
         category === "All"
             ? MOCK_POSTS
             : MOCK_POSTS.filter((post) => post.category === category);
-    const recentPosts = MOCK_POSTS.slice(0, 3); // 슬라이드에 보일 가장 최근 게시물 3개
-    const [currentSlide, setCurrentSlide] = useState(0); // 현재 슬라이드 번호
-    let slidePost = recentPosts[currentSlide]; // 현재 슬라이드 게시물
-    function nextCard() {
-        if (currentSlide === 2) setCurrentSlide(0);
-        else setCurrentSlide(currentSlide + 1);
-    }
-    function prevCard() {
-        if (currentSlide === 0) setCurrentSlide(2);
-        else setCurrentSlide(currentSlide - 1);
-    }
+
     return (
         <div>
             <main className="container max-w-4xl mx-auto px-6 py-12">
-                <section className={`${category !== "All" && "hidden"}`}>
-                    <div className="container max-w-full relative aspect-[21/9] rounded-2xl overflow-hidden bg-gray-100 dark:bg-gray-500">
-                        <a href={`/posts/${slidePost.id}`}>
-                            <img
-                                src={slidePost.thumbnail}
-                                alt={slidePost.title}
-                                className="object-cover w-full h-full"
-                            />
-                            <div className="absolute text-gray-50 bottom-0 px-9 py-8 flex sm:flex-col gap-2 items-center sm:items-start">
-                                <h1 className="text-lg sm:text-2xl md:text-3xl font-bold text-gray-100">
-                                    {slidePost.title}
-                                </h1>
-                                <p className="text-sm sm:text-base md:text-lg text-gray-200">
-                                    {slidePost.date}
-                                </p>
-                            </div>
-                        </a>
+                {category === "All" && (
+                    <FeaturedSlider posts={MOCK_POSTS.slice(0, 3)} />
+                )}
 
-                        <div className="absolute top-1/2 left-4">
-                            <button
-                                onClick={() => prevCard()}
-                                className="bg-gray-600/30 backdrop-blur-sm hover:bg-gray-600/60 rounded-full h-10 w-10 transition-colors"
-                            >
-                                <IoIosArrowBack className="w-6 h-6 ml-[7px] text-gray-50" />
-                            </button>
-                        </div>
-                        <div className="absolute top-1/2 right-4">
-                            <button
-                                onClick={() => nextCard()}
-                                className="bg-gray-600/30  backdrop-blur-sm hover:bg-gray-600/60 rounded-full h-10 w-10 transition-colors"
-                            >
-                                <IoIosArrowForward className="w-6 h-6 ml-[9px] text-gray-50" />
-                            </button>
-                        </div>
-                        <div className="absolute bottom-4 max-w-full container flex items-center justify-center space-x-2">
-                            <button
-                                onClick={() => setCurrentSlide(0)}
-                                className={`hover:cursor-default ${currentSlide === 0 ? "bg-gray-50" : "bg-gray-400"} ${currentSlide === 0 ? "w-8" : "w-2"} h-2 rounded-xl transition-all`}
-                            ></button>
-                            <button
-                                onClick={() => setCurrentSlide(1)}
-                                className={`hover:cursor-default ${currentSlide === 1 ? "bg-gray-50" : "bg-gray-400"} ${currentSlide === 1 ? "w-8" : "w-2"} h-2 rounded-xl transition-all`}
-                            ></button>
-                            <button
-                                onClick={() => setCurrentSlide(2)}
-                                className={`hover:cursor-default ${currentSlide === 2 ? "bg-gray-50" : "bg-gray-400"} ${currentSlide === 2 ? "w-8" : "w-2"} h-2 rounded-xl transition-all`}
-                            ></button>
-                        </div>
-                    </div>
-                </section>
+                <CategoryFiler />
 
-                <section className="my-12 flex space-x-3 items-center font-semibold max-w-4xl">
-                    <button
-                        onClick={() => setCategory("All")}
-                        className={`h-10 w-16 rounded-3xl 
-                        ${
-                            category === "All"
-                                ? "bg-primary text-gray-50 dark:bg-primary-dark"
-                                : "bg-gray-50 text-gray-600 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-                        }`}
-                    >
-                        All
-                    </button>
-                    <div className="flex space-x-3">
-                        {categoryList.map((c, idx) => (
-                            <button
-                                key={idx}
-                                onClick={() => setCategory(c)}
-                                className={`h-10 w-16 rounded-3xl
-                        ${
-                            category === c
-                                ? "bg-primary text-gray-50 dark:bg-primary-dark"
-                                : "bg-gray-50 text-gray-600 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-                        }`}
-                            >
-                                {c}
-                            </button>
-                        ))}
-                    </div>
-                </section>
-
-                <section className="mb-16 max-w-4xl mx-auto">
-                    <div className="container grid grid-cols-1 sm:grid-cols-2 gap-12 items-start max-w-full ">
-                        {filteredPosts.map((p: Post) => (
-                            <PostCard key={p.id} post={p} />
-                        ))}
-                    </div>
-                </section>
+                <PostGrid posts={filteredPosts} />
             </main>
         </div>
     );


### PR DESCRIPTION
### 관련 이슈 #12 

### PR 타입
기능 추가 및 개선

### 반영 브랜치
`refactor/home` -> `develop`

### 작업 내용
- [x] 기존 Home에 있던 슬라이더, 카테고리 필터링, 게시물 목록 기능을 컴포넌트화
- [x] Context API를 사용하여 `category` 상태를 전역으로 관리 

### 주요 변경 사항
#### 1. 컴포넌트 분리 리팩토링
- `FeaturedSlider.tsx` : 기존 Home에 있었던 슬라이더를 컴포넌트화 
  -  `Home`으로 부터 최근 게시물 목록(현재는 3개)을 **props**로 받음
  - `currentSlide` : 현재 슬라이드 상태를 **state**로 관리
  - `nextCard`, `prevCard` : 슬라이드 이동 로직
  
- `CategoryFilter.tsx` : 기존 Home에 있었던 카테고리 필터링을 컴포넌트 화
  - CategoryContext 를 직접 참조하고, 변경할 수 있도록 함
  
- `PostGrid` : 기존 Home에 있었던 게시물 목록을 컴포넌트화
  - 필터링된 포스트 목록을 **props**로 받음

#### 2. Context API 도입 
- `CategoryProvider`를 통해 카테고리 상태를 전역적으로 관리
- `useCategory` 커스텀 훅을 생성하여 접근할 수 있도록 함