### PR TITLE
[Feature] 서버 핵심 기능 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ server/bin/
 # IntelliJ settings
 server/.idea/
 server/*.iml
+
+# 서버 설정 파일
+server/src/main/resources/application.properties

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -18,17 +18,15 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-h2console'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testCompileOnly 'org.projectlombok:lombok'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/blog/server/controller/PostController.java
+++ b/server/src/main/java/com/blog/server/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.blog.server.controller;
 
 import com.blog.server.model.Post;
+import com.blog.server.model.PostSummary;
 import com.blog.server.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,7 +24,7 @@ public class PostController {
         if(category == null || category.equalsIgnoreCase("All")){
             return ResponseEntity.ok(postRepository.findAllByOrderByCreatedAtDesc());
         }
-        List<Post> filteredPost = postRepository.findAllByCategoryOrderByCreatedAtDesc(category);
+        List<PostSummary> filteredPost = postRepository.findAllByCategoryOrderByCreatedAtDesc(category);
         if(filteredPost.isEmpty()){
             return ResponseEntity.badRequest().body("잘못된 카테고리명입니다: " + category);
         }
@@ -31,7 +32,7 @@ public class PostController {
     }
 
     @GetMapping("/featured")
-    public List<Post> getFeatured(){
+    public List<PostSummary> getFeatured(){
         return postRepository.findTop3ByOrderByCreatedAtDesc();
     }
 

--- a/server/src/main/java/com/blog/server/controller/PostController.java
+++ b/server/src/main/java/com/blog/server/controller/PostController.java
@@ -46,8 +46,13 @@ public class PostController {
     }
 
     @GetMapping("/categories")
-    public List<String> getCategories(){
-        return postRepository.findDistinctCategories();
+    public List<String> getCategoryList(){
+        return postRepository.findAll()
+                .stream()
+                .map(Post::getCategory)
+                .distinct()
+                .filter(c -> c != null)
+                .toList();
     }
 
 }

--- a/server/src/main/java/com/blog/server/controller/PostController.java
+++ b/server/src/main/java/com/blog/server/controller/PostController.java
@@ -3,6 +3,8 @@ package com.blog.server.controller;
 import com.blog.server.model.Post;
 import com.blog.server.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -17,11 +19,15 @@ public class PostController {
     private final PostRepository postRepository;
 
     @GetMapping
-    public List<Post> getPosts(@RequestParam(value="category", required = false) String category) {
+    public ResponseEntity<?> getPosts(@RequestParam(value="category", required = false) String category) {
         if(category == null || category.equalsIgnoreCase("All")){
-            return postRepository.findAllByOrderByCreatedAtDesc();
+            return ResponseEntity.ok(postRepository.findAllByOrderByCreatedAtDesc());
         }
-        return postRepository.findAllByCategoryOrderByCreatedAtDesc(category);
+        List<Post> filteredPost = postRepository.findAllByCategoryOrderByCreatedAtDesc(category);
+        if(filteredPost.isEmpty()){
+            return ResponseEntity.badRequest().body("잘못된 카테고리명입니다: " + category);
+        }
+        return ResponseEntity.ok(filteredPost);
     }
 
     @GetMapping("/featured")
@@ -30,8 +36,11 @@ public class PostController {
     }
 
     @GetMapping("/{id}")
-    public Post getPost(@PathVariable("id") String id){
-        return postRepository.findById(id).orElseThrow();
+    public ResponseEntity<?> getPost(@PathVariable("id") String id) { // <Post>를 <?>로 변경
+        return postRepository.findById(id)
+                .<ResponseEntity<?>>map(post -> ResponseEntity.ok(post))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body("해당 ID의 게시글을 찾을 수 없습니다: " + id));
     }
 
     @GetMapping("/{id}/navigation")

--- a/server/src/main/java/com/blog/server/controller/PostController.java
+++ b/server/src/main/java/com/blog/server/controller/PostController.java
@@ -1,0 +1,53 @@
+package com.blog.server.controller;
+
+import com.blog.server.model.Post;
+import com.blog.server.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+@CrossOrigin(origins = "*")
+public class PostController {
+    private final PostRepository postRepository;
+
+    @GetMapping
+    public List<Post> getPosts(@RequestParam(value="category", required = false) String category) {
+        if(category == null || category.equalsIgnoreCase("All")){
+            return postRepository.findAllByOrderByCreatedAtDesc();
+        }
+        return postRepository.findAllByCategoryOrderByCreatedAtDesc(category);
+    }
+
+    @GetMapping("/featured")
+    public List<Post> getFeatured(){
+        return postRepository.findTop3ByOrderByCreatedAtDesc();
+    }
+
+    @GetMapping("/{id}")
+    public Post getPost(@PathVariable("id") String id){
+        return postRepository.findById(id).orElseThrow();
+    }
+
+    @GetMapping("/{id}/navigation")
+    public Map<String, Object> getNavigation(@PathVariable("id") String id){
+        Post current = postRepository.findById(id).orElseThrow();
+        Map<String, Object> nav = new HashMap<>();
+
+        nav.put("prev", postRepository.findFirstByCategoryAndIdLessThanOrderByIdDesc(current.getCategory(), id).orElse(null));
+        nav.put("next", postRepository.findFirstByCategoryAndIdGreaterThanOrderByIdAsc(current.getCategory(), id).orElse(null));
+
+        return nav;
+    }
+
+    @GetMapping("/categories")
+    public List<String> getCategories(){
+        return postRepository.findDistinctCategories();
+    }
+
+}

--- a/server/src/main/java/com/blog/server/model/Post.java
+++ b/server/src/main/java/com/blog/server/model/Post.java
@@ -1,5 +1,6 @@
 package com.blog.server.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
@@ -18,5 +19,7 @@ public class Post {
     private String content;
     private String category;
     private String thumbnail;
+
+    @JsonFormat(pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
     private LocalDateTime createdAt = LocalDateTime.now();
 }

--- a/server/src/main/java/com/blog/server/model/Post.java
+++ b/server/src/main/java/com/blog/server/model/Post.java
@@ -1,0 +1,22 @@
+package com.blog.server.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Document(collection = "posts")
+@Getter
+@NoArgsConstructor
+public class Post {
+    @Id
+    private String id;
+
+    private String title;
+    private String content;
+    private String category;
+    private String thumbnail;
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/server/src/main/java/com/blog/server/model/PostSummary.java
+++ b/server/src/main/java/com/blog/server/model/PostSummary.java
@@ -1,5 +1,7 @@
 package com.blog.server.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.LocalDateTime;
 
 public interface PostSummary {
@@ -7,5 +9,6 @@ public interface PostSummary {
     String getTitle();
     String getCategory();
     String getThumbnail();
+    @JsonFormat(pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
     LocalDateTime getCreatedAt();
 }

--- a/server/src/main/java/com/blog/server/model/PostSummary.java
+++ b/server/src/main/java/com/blog/server/model/PostSummary.java
@@ -1,0 +1,11 @@
+package com.blog.server.model;
+
+import java.time.LocalDateTime;
+
+public interface PostSummary {
+    String getId();
+    String getTitle();
+    String getCategory();
+    String getThumbnail();
+    LocalDateTime getCreatedAt();
+}

--- a/server/src/main/java/com/blog/server/repository/PostRepository.java
+++ b/server/src/main/java/com/blog/server/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.blog.server.repository;
 
 import com.blog.server.model.Post;
+import com.blog.server.model.PostSummary;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
@@ -8,14 +9,14 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends MongoRepository<Post, String> {
-    List<Post> findAllByOrderByCreatedAtDesc(); // 모든 글 조회
-    List<Post> findAllByCategoryOrderByCreatedAtDesc(String category); // 카테고리 필터링
-    List<Post> findTop3ByOrderByCreatedAtDesc(); // 최근 3개 게시물 조회
+    List<PostSummary> findAllByOrderByCreatedAtDesc(); // 모든 글 조회
+    List<PostSummary> findAllByCategoryOrderByCreatedAtDesc(String category); // 카테고리 필터링
+    List<PostSummary> findTop3ByOrderByCreatedAtDesc(); // 최근 3개 게시물 조회
 
     @Query(value = "{}", fields = "{'category' : 1}")
     List<String> findDistinctCategories(); // 모든 카테고리 조회
 
     // 이전글 / 다음글 용
-    Optional<Post> findFirstByCategoryAndIdLessThanOrderByIdDesc(String category, String id);
-    Optional<Post> findFirstByCategoryAndIdGreaterThanOrderByIdAsc(String category, String id);
+    Optional<PostSummary> findFirstByCategoryAndIdLessThanOrderByIdDesc(String category, String id);
+    Optional<PostSummary> findFirstByCategoryAndIdGreaterThanOrderByIdAsc(String category, String id);
 }

--- a/server/src/main/java/com/blog/server/repository/PostRepository.java
+++ b/server/src/main/java/com/blog/server/repository/PostRepository.java
@@ -1,0 +1,21 @@
+package com.blog.server.repository;
+
+import com.blog.server.model.Post;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostRepository extends MongoRepository<Post, String> {
+    List<Post> findAllByOrderByCreatedAtDesc(); // 모든 글 조회
+    List<Post> findAllByCategoryOrderByCreatedAtDesc(String category); // 카테고리 필터링
+    List<Post> findTop3ByOrderByCreatedAtDesc(); // 최근 3개 게시물 조회
+
+    @Query(value = "{}", fields = "{'category' : 1}")
+    List<String> findDistinctCategories(); // 모든 카테고리 조회
+
+    // 이전글 / 다음글 용
+    Optional<Post> findFirstByCategoryAndIdLessThanOrderByIdDesc(String category, String id);
+    Optional<Post> findFirstByCategoryAndIdGreaterThanOrderByIdAsc(String category, String id);
+}


### PR DESCRIPTION
### 관련 이슈 #14 

### PR 타입
기능 추가 및 개선

### 반영 브랜치
`feature/server` -> `develop`

### 작업 내용
- [x] 핵심 기능 API 추가
- [x] 로컬의 mongoDB 연결

### 주요 변경 사항
### 1. 핵심 기능 API 개발
- 모든 게시글 조회, 특정 카테고리 게시글 조회, 슬라이더용 최신 3개 글 조회, 현재 글 기준 이전/다음글 조회에는 `PostSummary` 타입을 사용하여 게시글의 기본 정보만 반환한다.
- 특정 ID의 글 상세 조회 API 만 게시글의 `content` 를 포함해 정보를 반환한다.
- 날짜는 `yyyy.MM.dd` 형식으로 바꾼 뒤 반환한다.

#### GET `/api/posts`
모든 게시글을 조회
<img width="1015" height="1086" alt="스크린샷 2026-04-20 오후 8 47 29" src="https://github.com/user-attachments/assets/51da2f33-20c9-41b0-9357-8b4b62c6803d" />

#### GET `/api/posts?category={category}` 
특정 카테고리 게시글 조회
<img width="1015" height="1086" alt="스크린샷 2026-04-20 오후 8 49 19" src="https://github.com/user-attachments/assets/66197a7c-bd63-4b5f-8364-d676a6dacd96" />

만약 존재하지 않은 카테고리를 조회한 경우 `400 Bad Request` 반환
<img width="1015" height="1086" alt="스크린샷 2026-04-20 오후 8 49 02" src="https://github.com/user-attachments/assets/e73d65eb-00ed-4a0b-8ef6-48cd76ec066b" />

#### GET `/api/posts/featured` 
슬라이더용 최신 글 조회(3개)
<img width="1015" height="1086" alt="스크린샷 2026-04-20 오후 8 48 12" src="https://github.com/user-attachments/assets/b5ce8338-ea42-4eb0-b264-9da38912605d" />

#### GET `/api/posts/{id}`
특정 ID의 글 상세 조회
<img width="1015" height="1086" alt="스크린샷 2026-04-20 오후 8 48 23" src="https://github.com/user-attachments/assets/032e92c1-4c7b-4fe7-b41d-72d9addc13e8" />

#### GET `/api/posts/{id}/navigation` 
현재 글 기준 이전/다음글 ID 및 제목
<img width="1015" height="1086" alt="스크린샷 2026-04-20 오후 8 48 31" src="https://github.com/user-attachments/assets/da36f0ee-35db-466a-ab8d-426509b2f9d3" />

#### GET `/api/categories` 
카테고리 종류 조회
<img width="1015" height="1086" alt="스크린샷 2026-04-20 오후 8 48 39" src="https://github.com/user-attachments/assets/9abbaf46-284c-4148-9ecd-0ed41566d93e" />
